### PR TITLE
Use yapm init to create a package.json5 or package.yml [#3]

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -175,6 +175,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , "init-version": "1.0.0"
     , "init-license": "ISC"
     , json: false
+    , "json5": false
     , key: null
     , link: false
     , "local-address" : undefined
@@ -231,6 +232,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , version : false
     , versions : false
     , viewer: process.platform === "win32" ? "browser" : "man"
+    , yaml: false
     , "yapm-formats": "yaml,json5,json,indexjs"
 
     , _exit : true
@@ -280,6 +282,7 @@ exports.types =
   , "init-license": String
   , "init-version": semver
   , json: Boolean
+  , "json5": Boolean
   , key: [null, String]
   , link: Boolean
   // local-address must be listed as an IP for a local network interface
@@ -333,6 +336,7 @@ exports.types =
   , versions : Boolean
   , viewer: String
   , "yapm-formats": [String]
+  , yaml: Boolean
   , _exit : Boolean
   }
 
@@ -386,4 +390,6 @@ exports.shorthands =
   , n : ["--no-yes"]
   , B : ["--save-bundle"]
   , C : ["--prefix"]
+  , yaml : ["--yaml"]
+  , j5 : ["--json5"]
   }

--- a/lib/init.js
+++ b/lib/init.js
@@ -6,15 +6,24 @@ module.exports = init
 var log = require("npmlog")
   , npm = require("./npm.js")
   , initJson = require("init-package-json")
+  , fs = require("fs")
+  , path = require("path")
+  , read = require("read")
+  , jju = require("jju")
+  , yaml = require("js-yaml")
 
-init.usage = "npm init [--force/-f]"
+init.usage = "yapm init [--force/-f] [--yaml] [--json5]"
 
 function init (args, cb) {
   var dir = process.cwd()
   log.pause()
   npm.spinner.stop()
   var initFile = npm.config.get("init-module")
-  if (!initJson.yes(npm.config)) {
+
+  var yes = initJson.yes(npm.config)
+  var newFormat = npm.config.get("json5") || npm.config.get("yaml")
+
+  if (!yes) {
     console.log(
       ["This utility will walk you through creating a package.json file."
       ,"It only covers the most common items, and tries to guess sane defaults."
@@ -27,15 +36,102 @@ function init (args, cb) {
       ,""
       ,"Press ^C at any time to quit."
       ].join("\n"))
+
+    // new formats skip NPM questions and ask YAPM questions
+    if (newFormat) {
+      npm.config.set('yes', true)
+    }
   }
-  initJson(dir, initFile, npm.config, function (er, data) {
+
+  initJson(dir, initFile, npm.config, function (er, pkgData) {
     log.resume()
-    log.silly("package data", data)
+    log.silly("package data", pkgData)
     if (er && er.message === "canceled") {
       log.warn("init", "canceled")
-      return cb(null, data)
+      return cb(null, pkgData)
     }
     log.info("init", "written successfully")
-    cb(er, data)
+
+    if (newFormat) {
+      // let user confirm output text
+      var verifyOutput = function(outpath, output, cb) {
+        console.log('About to write to %s:\n\n%s\n', outpath, output)
+        read({prompt:'Is this ok? ', default: 'yes'}, cb)
+      }
+
+      // generate and save output text
+      var savePackage = function (pkgFinal, cb) {
+        if (npm.config.get("json5")) {
+          var json5Pkg = jju.stringify(pkgFinal)
+          outputPath = path.resolve(dir, "package.json5")
+
+          verifyOutput(outputPath, json5Pkg, function(er, ok) {
+            if (ok) {
+              fs.writeFile(outputPath, json5Pkg, function(er) {
+                if (er) {
+                  log.warn("init", "canceled")
+                  return cb(null, data)
+                }
+
+                cb(er, pkgFinal)
+              })
+            } else {
+              console.log('Aborted.')
+            }
+          })
+        }
+        else if (npm.config.get("yaml")) {
+          var yamlPkg = yaml.safeDump(pkgFinal)
+          var outputPath = path.resolve(dir, "package.yml")
+
+          verifyOutput(outputPath, yamlPkg, function(er, ok) {
+            if (ok) {
+              fs.writeFile(outputPath, yamlPkg, function(er) {
+                if (er) {
+                  log.warn("init", "canceled")
+                  return cb(null, data)
+                }
+
+                return cb(er, pkgFinal)
+              })
+            } else {
+              console.log('Aborted.')
+            }
+          })
+        }
+      }
+
+      // allow user to skip custom questions using -y
+      console.log('converting for YAPM...')
+      if (yes) {
+        savePackage(pkgData, cb)
+      } else {
+        // mimic the NPM questions and set the package accordingly
+        read({prompt:"name ", default: pkgData.name}, function(er, name) {
+          if (er) {
+            return cb(er, pkgData)
+          }
+          var ver = pkgData.version ||
+                    npm.config.get('init.version') ||
+                    npm.config.get('init-version') ||
+                    '1.0.0'
+          read({prompt: "version ", default: ver}, function(er, version) {
+            read({prompt: "license ", default: pkgData.license}, function(er, license) {
+              pkgData.name = name
+              pkgData.version = version
+              pkgData.license = license
+              savePackage(pkgData, cb)
+            })
+          })
+        })
+      }
+    }
+    else {
+      // output a regular JSON file
+      outputPath = path.resolve(dir, "package.json")
+      fs.writeFile(outputPath, JSON.stringify(pkgData), function(er) {
+        return cb(er, pkgData)
+      })
+    }
   })
 }


### PR DESCRIPTION
This allows you to run `yapm init --json5` or `yapm init --yaml` to create a package file.

Currently it asks the same questions as `npm init`, shows the desired output format, asks for the user's approval, then writes the file. If you add `-y`, it skips directly to getting the user's approval.
